### PR TITLE
継承周りを修正。

### DIFF
--- a/lib/base/base.js
+++ b/lib/base/base.js
@@ -35,15 +35,10 @@ var TTL = 3600;
 var Base = function (db, name) {
   this.class = 'Base';
   this.name = name || this.class;
-  if (!this.initialized[this.class]) {
     this.database = db || DB;
     this.fields = fields;
-    this.initialized[this.class] = true;
-  }
   return this;
 };
-
-Base.prototype.initialized = {};
 
 /**
  * フィールド定義
@@ -61,21 +56,6 @@ Base.prototype.collection = function () {
 };
 
 /**
- * prototypeチェーン実装 (サブクラスから親クラスの関数の実行)
- * @param name : 関数名
- * @param 引数
- */
-Base.prototype.parent = function (name) {
-  var self = this;
-  while (!self.hasOwnProperty(name)) self = self.super_; // step 1
-  self = self.super_ || self;
-  while (!self.hasOwnProperty(name)) self = self.super_; // step 2
-  var arg = [];
-  for (var i = 1; i < arguments.length; i++) arg.push(arguments[i]);
-  self[name].apply(self, arg);
-};
-
-/**
  * 処理実行
  * @param context  : 追加情報
  * @param name     : 関数名称
@@ -84,7 +64,7 @@ Base.prototype.parent = function (name) {
  */
 Base.prototype.execute = function (name, context, params, callback) {
   var self = this;
-  context.module = context.module || this;
+
   async.waterfall([
       function (next) {
         self['before_' + name].call(self, context, params, function (err, params) {
@@ -122,16 +102,20 @@ Base.prototype.findOne = function (context, params, callback) {
 };
 
 Base.prototype.before_findOne = function (context, params, callback) {
+  var self = this;
+
   params.query = params.query || {};
-  context.module.validator(context.module.fields, params.query, function (err, query) {
+  self.validator(self.fields, params.query, function (err, query) {
     callback(err, params);
   });
 };
 
 Base.prototype.do_findOne = function (context, params, callback) {
+  var self = this;
+
   var query = params.query || {};
   var options = {fields: params.fields};
-  context.module.collection().findOne(query, options, function (err, object) {
+  self.collection().findOne(query, options, function (err, object) {
     callback(err, object);
   });
 };
@@ -154,17 +138,21 @@ Base.prototype.find = function (context, params, callback) {
 };
 
 Base.prototype.before_find = function (context, params, callback) {
+  var self = this;
+
   params.query = params.query || {};
-  context.module.validator(context.module.fields, params.query, function (err) {
+  self.validator(self.fields, params.query, function (err) {
     callback(err, params);
   });
 };
 
 Base.prototype.do_find = function (context, params, callback) {
+  var self = this;
+
   var query = params.query || {};
   var options = params.options || {};
   options.fields = params.fields;
-  context.module.collection().find(query, options).toArray(function (err, objects) {
+  self.collection().find(query, options).toArray(function (err, objects) {
     callback(err, objects);
   });
 };
@@ -187,18 +175,22 @@ Base.prototype.update = function (context, params, callback) {
 };
 
 Base.prototype.before_update = function (context, params, callback) {
+  var self = this;
+
   params.query = params.query || {};
-  context.module.validator(context.module.fields, params.query, function (err) {
-    context.module.validator(context.module.fields, params.values, function (err) {
+  self.validator(self.fields, params.query, function (err) {
+    self.validator(self.fields, params.values, function (err) {
       callback(err, params);
     });
   });
 };
 
 Base.prototype.do_update = function (context, params, callback) {
+  var self = this;
+
   var query = params.query || {};
   var values = params.values || {};
-  context.module.findAndModify(query, values, function (err, object) {
+  self.findAndModify(query, values, function (err, object) {
     callback(err, object);
   })
 };
@@ -219,15 +211,19 @@ Base.prototype.destroy = function (context, params, callback) {
 };
 
 Base.prototype.before_destroy = function (context, params, callback) {
+  var self = this;
+
   params.query = params.query || {};
-  context.module.validator(context.module.fields, params.query, function (err) {
+  self.validator(self.fields, params.query, function (err) {
     callback(err, params);
   });
 };
 
 Base.prototype.do_destroy = function (context, params, callback) {
+  var self = this;
+
   var query = params.query || {};
-  context.module.findAndRemove(query, function (err, object) {
+  self.findAndRemove(query, function (err, object) {
     callback(err, object);
   })
 };

--- a/lib/base/paranoia.js
+++ b/lib/base/paranoia.js
@@ -19,11 +19,8 @@ var fields = {
 var ParanoiaBase = DB.inherits(Base, function (db, name) {
   this.class = 'ParanoiaBase';
   this.name = name || this.class;
-  if (!this.initialized[this.class]) {
-    this.super_.constructor(db, this.name);
-    this.fields = DB.extend(fields, this.fields);
-    this.initialized[this.class] = true;
-  }
+  Base.call(this, db, this.name); // call super constructor
+  this.fields = DB.extend(fields, this.fields);
   return this;
 });
 
@@ -33,7 +30,8 @@ var ParanoiaBase = DB.inherits(Base, function (db, name) {
  * @param callback
  */
 ParanoiaBase.prototype.before_findOne = function (context, params, callback) {
-  this.parent('before_findOne', context, params, function (err, params) {
+  // call super method
+  ParanoiaBase.prototype.super_.before_findOne.call(this, context, params, function (err, params) {
     paranoia_query(params);
     callback(err, params);
   });
@@ -45,7 +43,8 @@ ParanoiaBase.prototype.before_findOne = function (context, params, callback) {
  * @param callback
  */
 ParanoiaBase.prototype.before_find = function (context, params, callback) {
-  this.parent('before_find', context, params, function (err, params) {
+  // call super method
+  ParanoiaBase.prototype.super_.before_find.call(this, context, params, function (err, params) {
     paranoia_query(params);
     callback(err, params);
   });

--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -46,9 +46,7 @@ exports.inherits = function (s, c) {
       configurable: true
     }
   });
-//c.prototype.constructor = c;
   c.prototype.super_ = s.prototype;
-  c.prototype.super_.constructor = s;
   return c;
 };
 

--- a/lib/filesystem/s3-mongo.js
+++ b/lib/filesystem/s3-mongo.js
@@ -26,11 +26,8 @@ var S3Index = DB.inherits(Base, function (db, name) {
   this.class = 'S3Index';
   this.name = name || this.class;
   this.s3 = new S3(this.name);
-  if (!this.initialized[this.class]) {
-    this.super_.constructor(db, this.name);
+    Base.call(this, db, this.name); // call super constructor
     this.fields = DB.extend(fields, this.fields);
-    this.initialized[this.class] = true;
-  }
   return this;
 });
 
@@ -66,7 +63,8 @@ S3Index.prototype.after_findOne = function (context, params, object, callback) {
   var self = this;
   async.waterfall([
       function (next) {
-        self.parent('after_findOne', context, params, object, function (err, object) {
+        // call super method
+        S3Index.prototype.super_.after_findOne.call(self, context, params, object, function (err, object) {
           next(err, object);
         });
       },
@@ -100,7 +98,8 @@ S3Index.prototype.before_update = function (context, params, callback) {
   var self = this;
   async.waterfall([
       function (next) {
-        self.parent('before_update', context, params, function (err, params) {
+        // call super method
+        S3Index.prototype.super_.before_update.call(self, context, params, function (err, params) {
           next(err, params);
         });
       },
@@ -146,7 +145,8 @@ S3Index.prototype.before_update = function (context, params, callback) {
  */
 S3Index.prototype.after_update = function (context, params, object, callback) {
   var self = this;
-  self.parent('after_update', context, params, object, function (err, params) {
+  // call super method
+  S3Index.prototype.super_.after_update.call(self, context, params, object, function (err, params) {
     // サムネイルの生成
     var format = self.resize_format;
     var type = object.contentType;


### PR DESCRIPTION
親クラスのコンストラクタ・関数を呼び出す方法を変更する
ことで記述を簡易化。
