### PR TITLE
findAndModifyにオプション追加(upsert対応)

### DIFF
--- a/lib/base/base.js
+++ b/lib/base/base.js
@@ -237,7 +237,8 @@ Base.prototype.do_update = function (context, params, callback) {
   var self = this;
   var query = params.query || {};
   var values = params.values || {};
-  self.findAndModify(context, query, values, function (err, object) {
+  var options = params.options || {};
+  self.findAndModify(context, query, values, options, function (err, object) {
     callback(err, object);
   })
 };
@@ -320,12 +321,14 @@ Base.prototype.insert = function (context, query, values, callback) {
  * @param values    値
  * @param callback
  */
-Base.prototype.findAndModify = function (context, query, values, callback) {
+Base.prototype.findAndModify = function (context, query, values, options, callback) {
   var collection = this.collection();
   values = copy(values); // 変更するためシャローコピー
 
   values.updatedAt = new Date();
   values.updatedBy = context.user ? { _id: context.user._id } : null;
+
+  var upsert = options.upsert || false;
 
   // MongoDB 2.6 からは、_id は $set: values に存在していればよい。
   // MongoDB 2.4 では、$set: values に存在している場合エラー。$setOnInsert に必要。
@@ -341,7 +344,7 @@ Base.prototype.findAndModify = function (context, query, values, callback) {
         createdAt: values.updatedAt,
         createdBy: values.updatedBy}
     },
-    {upsert: false, new: true},
+    {upsert: upsert, new: true},
     function (err, result) {
       callback(err, result);
     }

--- a/lib/base/paranoia.js
+++ b/lib/base/paranoia.js
@@ -86,7 +86,8 @@ ParanoiaBase.prototype.before_delete = function (context, params, callback) {
 ParanoiaBase.prototype.do_delete = function (context, params, callback) {
   var query = params.query || {};
   var values = {deletedAt: new Date()};
-  this.findAndModify(context, query, values, function (err, object) {
+  var options = params.options || {};
+  this.findAndModify(context, query, values, options, function (err, object) {
     callback(err, object);
   })
 };

--- a/test/mongo/test.js
+++ b/test/mongo/test.js
@@ -50,6 +50,13 @@ describe('Mongo', function () {
     contentType: 'text/plain'
   };
 
+  var params03 = {
+    _id: 'test03',
+    filename: 'test03',
+    length: 130,
+    contentType: 'text/html'
+  };
+
   var params1 = {
     _id: 'test1',
     filename: 'test1',
@@ -223,6 +230,19 @@ describe('Mongo', function () {
     });
   });
 
+  it('Update(Upsert). not exist document', function (done) {
+
+    var base1 = new Base1(null, test_backet);
+
+    base1.update(context, {query: {_id: params02._id}, values: params02, options: {upsert: true}}, function (err, result) {
+
+      (err === null).should.be.true;
+      (result === null).should.be.false;
+
+      done();
+    });
+  });
+
   it('List.', function (done) {
 
     var base1 = new Base1(null, test_backet);
@@ -243,15 +263,15 @@ describe('Mongo', function () {
     var base0 = new Base0(null, test_backet); // 物理削除
     var base1 = new Base1(null, test_backet); // 論理削除
 
-    base1.create(context, {query: {_id: params02._id}, values: params02}, function (err, result) {
-      base1.delete(context, {query: {_id: params02._id}}, function (err, result) {
-        base1.findOne(context, {query: {_id: params02._id}, fields: fields}, function (err, result) {
+    base1.create(context, {query: {_id: params03._id}, values: params03}, function (err, result) {
+      base1.delete(context, {query: {_id: params03._id}}, function (err, result) {
+        base1.findOne(context, {query: {_id: params03._id}, fields: fields}, function (err, result) {
           should.equal(result, null, '論理削除されているので見つからない');
-          base0.findOne(context, {query: {_id: params02._id}, fields: fields}, function (err, result) {
-            result._id = params02._id;
-            result.should.eql(params02, '論理削除ではないモジュールを使うと見つかる');
-            base0.destroy(context, {query: {_id: params02._id}}, function (err, result) {
-              base0.findOne(context, {query: {_id: params02._id}, fields: fields}, function (err, result) {
+          base0.findOne(context, {query: {_id: params03._id}, fields: fields}, function (err, result) {
+            result._id = params03._id;
+            result.should.eql(params03, '論理削除ではないモジュールを使うと見つかる');
+            base0.destroy(context, {query: {_id: params03._id}}, function (err, result) {
+              base0.findOne(context, {query: {_id: params03._id}, fields: fields}, function (err, result) {
                 should.equal(result, null, '物理削除されているので見つからない');
                 done();
               });


### PR DESCRIPTION
Module.update(context, params, callback)のparamsにoptionsを指定
することでupsertの指定が可能。デフォルトはupdate(upsert: false);

(例) upsert
var params = {
    query: {},
    values:{},
    options:{upsert: true}
};
Module.upsate(context, params callback);
