### PR TITLE
コンストラクター内でのself.fieldsの設定方法を変更

### DIFF
--- a/lib/base/base.js
+++ b/lib/base/base.js
@@ -42,10 +42,11 @@ var SORT_ORDER = '-1' // DESC: -1 ASC: 1
  * prototype プロパティを参照するのは new されて生成したインスタンスのみです。
  */
 var Base = function (db, name) {
+  // thisは継承元のインスタンス
   this.class = 'Base';
   this.name = name || this.class;
   this.database = db || DB;
-  this.fields = fields;
+  this.fields = DB.extend({}, fields);
   return this;
 };
 

--- a/lib/base/paranoia.js
+++ b/lib/base/paranoia.js
@@ -18,7 +18,7 @@ var fields = {
  */
 var ParanoiaBase = DB.inherits(Base, function (db, name) {
   Base.call(this, db, name || 'ParanoiaBase'); // call super constructor
-  this.fields = DB.extend(fields, this.fields);
+  DB.extend(this.fields, fields);
   return this;
 });
 

--- a/lib/filesystem/s3-mongo.js
+++ b/lib/filesystem/s3-mongo.js
@@ -25,7 +25,7 @@ var fields = {
 var S3Index = DB.inherits(Base, function (db, name) {
   Base.call(this, db, name || 'S3Index'); // call super constructor
   this.s3 = new S3(this.name);
-  this.fields = DB.extend(fields, this.fields);
+  DB.extend(this.fields, fields);
   return this;
 });
 


### PR DESCRIPTION
旧方式の場合、モジュールグローバルなfieldsを書き換えてしまっているかつ
トリッキーなコードになっていたので、見通しのよいコードに修正。
